### PR TITLE
SWTCH Network Token for EVM

### DIFF
--- a/contracts/token/SWTCH.sol
+++ b/contracts/token/SWTCH.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-3
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+
+/**
+ * @title SWTCH
+ * @author astor@swtch.network
+ * @notice SWTCH Network Token upgradeable ERC-20 implementation.
+ */
+contract SWTCH is Initializable, ERC20Upgradeable, OwnableUpgradeable {
+
+    /**
+     * @param owner Owner who received minted SWTCH.
+     * @param value Amount of SWTCH allocated to the Owner.
+     */
+    event AdminMint(address indexed owner, uint256 value);
+
+    /**
+     * @param initialSupply Initial token supply.
+     * @param admin SWTCH Network Token administrator.
+     */
+    function initialize(
+        uint256 initialSupply,
+        address admin
+    ) public initializer {
+        __ERC20_init("SWTCH Network Token", "SWTCH");
+        __Ownable_init(admin);
+        
+        _mint(admin, initialSupply);
+        // transferOwnership(admin);
+    }
+
+    /**
+     * @param newSupply New token supply to allocate to the owner.
+     */
+    function adminMint(uint256 newSupply) external onlyOwner {
+        _mint(owner(), newSupply);
+
+        emit AdminMint(owner(), newSupply);
+    }
+}

--- a/test/SWTCH.test.ts
+++ b/test/SWTCH.test.ts
@@ -1,0 +1,61 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+import { SWTCH } from "../typechain-types";
+
+describe("SWTCH Token", function () {
+    let SWTCH: SWTCH;
+    let owner: any;
+    let addr1: any;
+    let addr2: any;
+
+    beforeEach(async function () {
+        [owner, addr1, addr2] = await ethers.getSigners();
+
+        const SWTCHFactory = await ethers.getContractFactory("SWTCH");
+        SWTCH = await SWTCHFactory.deploy();
+        await SWTCH.getDeployedCode();
+
+        await SWTCH.initialize(ethers.parseEther("1000000000"), await owner.getAddress());
+    });
+
+    it("Should initialize the contract with the correct values", async function () {
+        expect(await SWTCH.name()).to.equal("SWTCH Network Token");
+        expect(await SWTCH.symbol()).to.equal("SWTCH");
+        expect(await SWTCH.totalSupply()).to.equal(ethers.parseEther("1000000000"));
+        expect(await SWTCH.balanceOf(await owner.getAddress())).to.equal(ethers.parseEther("1000000000"));
+    });
+
+    it("Should allow the owner to mint new tokens", async function () {
+        const allocation = ethers.parseEther("2000000000");
+        await SWTCH.adminMint(allocation);
+        expect(await SWTCH.totalSupply()).to.equal(ethers.parseEther("3000000000"));
+        expect(await SWTCH.balanceOf(owner.getAddress())).to.equal(ethers.parseEther("3000000000"));
+    });
+
+    it("Should emit AdminMint event when new tokens are minted", async function () {
+        const allocation = ethers.parseEther("1000000000");
+        await expect(SWTCH.adminMint(allocation))
+            .to.emit(SWTCH, "AdminMint")
+            .withArgs(await owner.getAddress(), allocation);
+    });
+
+    it("Should not allow non-owner to mint new tokens", async function () {
+        const allocation = ethers.parseEther("1000000000");
+        await expect(
+            SWTCH.connect(addr1).adminMint(allocation)
+        ).to.be.reverted;
+    });
+
+    it("Should transfer ownership correctly", async function () {
+        await SWTCH.transferOwnership(await addr1.getAddress());
+        expect(await SWTCH.owner()).to.equal(await addr1.getAddress());
+    });
+
+    it("Should allow new owner to mint tokens", async function () {
+        await SWTCH.transferOwnership(await addr1.getAddress());
+        await SWTCH.connect(addr1).adminMint(500);
+        expect(await SWTCH.totalSupply()).to.equal("1000000000000000000000000500");
+        expect(await SWTCH.balanceOf(await addr1.getAddress())).to.equal(500);
+    });
+});


### PR DESCRIPTION
Added the base SWTCH Network Token for evm blockchains and supporting unit tests.